### PR TITLE
Boxes table key is too long for primary key

### DIFF
--- a/SQL_exercise_03/3_build_schema.sql
+++ b/SQL_exercise_03/3_build_schema.sql
@@ -8,7 +8,7 @@ CREATE TABLE Warehouses (
    PRIMARY KEY (Code)
  );
 CREATE TABLE Boxes (
-    Code VARCHAR(255) NOT NULL,
+    Code CHAR(4) NOT NULL,
     Contents VARCHAR(255) NOT NULL ,
     Value REAL NOT NULL ,
     Warehouse INTEGER NOT NULL,


### PR DESCRIPTION
`Boxes` table creation fails on MariaDB 10.1.26 
mysql error (1071, 'Specified key was too long; max key length is 767 bytes')